### PR TITLE
Update parsing signed data to handle multiple octet strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,11 @@
 name: CI
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: [main]
 
 jobs:
   test:
     name: Test
-    strategy:
-      matrix:
-        go: ['1.12', '1.13', '1.14', '1.15', '1.16']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -14,7 +13,10 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v2
       with:
-        go-version: ${{ matrix.go }}
-        stable: false
+        go-version: "1.22.0"
+    - name: Vet
+      run: go vet .
+    - name: Build
+      run: go build .
     - name: Test
-      run: go vet . && go build . && go test -count=1 -covermode=count -coverprofile=coverage.out .
+      run: GODEBUG=x509sha1=1 go test -count=1 -covermode=count -coverprofile=coverage.out .

--- a/verify.go
+++ b/verify.go
@@ -210,8 +210,20 @@ func parseSignedData(data []byte) (*PKCS7, error) {
 	// Compound octet string
 	if compound.IsCompound {
 		if compound.Tag == 4 {
-			if _, err = asn1.Unmarshal(compound.Bytes, &content); err != nil {
-				return nil, err
+			var tempContent unsignedData
+
+			// Data is sometimes stored across multiple items
+			remainingBytes := compound.Bytes
+			for {
+				if remainingBytes, err = asn1.Unmarshal(remainingBytes, &tempContent); err != nil {
+					return nil, err
+				}
+
+				content = append(content, tempContent...)
+
+				if len(remainingBytes) == 0 {
+					break
+				}
 			}
 		} else {
 			content = compound.Bytes


### PR DESCRIPTION
Receipt from iOS uses multiple consecutive octet strings to store data