### PR TITLE
CI & Lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,45 @@
+---
 name: CI
-on: [push, pull_request]
+"on": [push, pull_request]
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
 
 jobs:
   test:
     name: Test
     strategy:
       matrix:
-        go: ['1.12', '1.13', '1.14', '1.15', '1.16']
+        go: ['1.17.x', '1.18.x', '1.19.x', '1.20.x', '1.21.x', '1.22.x', 'stable']
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
-        stable: false
-    - name: Test
-      run: go vet . && go build . && go test -count=1 -covermode=count -coverprofile=coverage.out .
+        cache: false
+    - name: go test
+      env:
+        GODEBUG: x509sha1=1
+      run: go vet . && go build . && go test .
+
+  golangci:
+    # Docs: https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#how-to-use
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: latest
+          only-new-issues: true
+          skip-cache: true
+          skip-pkg-cache: true
+          skip-build-cache: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+coverage.out
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,18 @@
-all: vet staticcheck test
+.PHONY: all
+all: lint vet test
 
+.PHONY: test
 test:
-	go test -covermode=count -coverprofile=coverage.out .
+	GODEBUG=x509sha1=1 go test -covermode=count -coverprofile=coverage.out .
 
+.PHONY: showcoverage
 showcoverage: test
 	go tool cover -html=coverage.out
 
+.PHONY: vet
 vet:
 	go vet .
 
+.PHONY: lint
 lint:
-	golint .
-
-staticcheck:
-	staticcheck .
-
-gettools:
-	go get -u honnef.co/go/tools/...
-	go get -u golang.org/x/lint/golint
+	golangci-lint run

--- a/ber.go
+++ b/ber.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 )
 
-var encodeIndent = 0
+// var encodeIndent = 0
 
 type asn1Object interface {
 	EncodeTo(writer *bytes.Buffer) error
@@ -17,8 +17,8 @@ type asn1Structured struct {
 }
 
 func (s asn1Structured) EncodeTo(out *bytes.Buffer) error {
-	//fmt.Printf("%s--> tag: % X\n", strings.Repeat("| ", encodeIndent), s.tagBytes)
-	encodeIndent++
+	// fmt.Printf("%s--> tag: % X\n", strings.Repeat("| ", encodeIndent), s.tagBytes)
+	// encodeIndent++
 	inner := new(bytes.Buffer)
 	for _, obj := range s.content {
 		err := obj.EncodeTo(inner)
@@ -26,9 +26,11 @@ func (s asn1Structured) EncodeTo(out *bytes.Buffer) error {
 			return err
 		}
 	}
-	encodeIndent--
+	// encodeIndent--
 	out.Write(s.tagBytes)
-	encodeLength(out, inner.Len())
+	if err := encodeLength(out, inner.Len()); err != nil {
+		return err
+	}
 	out.Write(inner.Bytes())
 	return nil
 }
@@ -47,8 +49,8 @@ func (p asn1Primitive) EncodeTo(out *bytes.Buffer) error {
 	if err = encodeLength(out, p.length); err != nil {
 		return err
 	}
-	//fmt.Printf("%s--> tag: % X length: %d\n", strings.Repeat("| ", encodeIndent), p.tagBytes, p.length)
-	//fmt.Printf("%s--> content length: %d\n", strings.Repeat("| ", encodeIndent), len(p.content))
+	// fmt.Printf("%s--> tag: % X length: %d\n", strings.Repeat("| ", encodeIndent), p.tagBytes, p.length)
+	// fmt.Printf("%s--> content length: %d\n", strings.Repeat("| ", encodeIndent), len(p.content))
 	out.Write(p.content)
 
 	return nil
@@ -58,18 +60,20 @@ func ber2der(ber []byte) ([]byte, error) {
 	if len(ber) == 0 {
 		return nil, errors.New("ber2der: input ber is empty")
 	}
-	//fmt.Printf("--> ber2der: Transcoding %d bytes\n", len(ber))
+	// fmt.Printf("--> ber2der: Transcoding %d bytes\n", len(ber))
 	out := new(bytes.Buffer)
 
 	obj, _, err := readObject(ber, 0)
 	if err != nil {
 		return nil, err
 	}
-	obj.EncodeTo(out)
+	if err := obj.EncodeTo(out); err != nil {
+		return nil, err
+	}
 
 	// if offset < len(ber) {
 	//	return nil, fmt.Errorf("ber2der: Content longer than expected. Got %d, expected %d", offset, len(ber))
-	//}
+	// }
 
 	return out.Bytes(), nil
 }
@@ -106,12 +110,12 @@ func lengthLength(i int) (numBytes int) {
 // added to 0x80. The length is encoded in big endian encoding follow after
 //
 // Examples:
-//  length | byte 1 | bytes n
-//  0      | 0x00   | -
-//  120    | 0x78   | -
-//  200    | 0x81   | 0xC8
-//  500    | 0x82   | 0x01 0xF4
 //
+//	length | byte 1 | bytes n
+//	0      | 0x00   | -
+//	120    | 0x78   | -
+//	200    | 0x81   | 0xC8
+//	500    | 0x82   | 0x01 0xF4
 func encodeLength(out *bytes.Buffer, length int) (err error) {
 	if length >= 128 {
 		l := lengthLength(length)
@@ -154,7 +158,7 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 			}
 		}
 		// jvehent 20170227: this doesn't appear to be used anywhere...
-		//tag = tag*128 + ber[offset] - 0x80
+		// tag = tag*128 + ber[offset] - 0x80
 		offset++
 		if offset > berLen {
 			return nil, 0, errors.New("ber2der: cannot move offset forward, end of ber data reached")
@@ -204,7 +208,7 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 	if length < 0 {
 		return nil, 0, errors.New("ber2der: invalid negative value found in BER tag length")
 	}
-	//fmt.Printf("--> length        : %d\n", length)
+	// fmt.Printf("--> length        : %d\n", length)
 	contentEnd := offset + length
 	if contentEnd > len(ber) {
 		return nil, 0, errors.New("ber2der: BER tag length is more than available data")
@@ -259,7 +263,7 @@ func readObject(ber []byte, offset int) (asn1Object, int, error) {
 }
 
 func isIndefiniteTermination(ber []byte, offset int) (bool, error) {
-	if len(ber) - offset < 2 {
+	if len(ber)-offset < 2 {
 		return false, errors.New("ber2der: Invalid BER format")
 	}
 
@@ -267,5 +271,5 @@ func isIndefiniteTermination(ber []byte, offset int) (bool, error) {
 }
 
 func debugprint(format string, a ...interface{}) {
-	//fmt.Printf(format, a)
+	// fmt.Printf(format, a)
 }

--- a/ber_test.go
+++ b/ber_test.go
@@ -73,7 +73,7 @@ func TestBer2Der_NestedMultipleIndefinite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ber2der failed with error: %v", err)
 	}
-	if bytes.Compare(der, expected) != 0 {
+	if !bytes.Equal(der, expected) {
 		t.Errorf("ber2der result did not match.\n\tExpected: % X\n\tActual: % X", expected, der)
 	}
 

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -290,7 +290,9 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 	if err != nil {
 		return nil, err
 	}
-	pem.Encode(os.Stdout, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	if err := pem.Encode(os.Stdout, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
+		return nil, err
+	}
 	return &certKeyPair{
 		Certificate: cert,
 		PrivateKey:  &priv,

--- a/sign.go
+++ b/sign.go
@@ -82,7 +82,9 @@ func marshalAttributes(attrs []attribute) ([]byte, error) {
 
 	// Remove the leading sequence octets
 	var raw asn1.RawValue
-	asn1.Unmarshal(encodedAttributes, &raw)
+	if _, err := asn1.Unmarshal(encodedAttributes, &raw); err != nil {
+		return nil, err
+	}
 	return raw.Bytes, nil
 }
 

--- a/verify.go
+++ b/verify.go
@@ -191,7 +191,9 @@ func (p7 *PKCS7) UnmarshalSignedAttribute(attributeType asn1.ObjectIdentifier, o
 
 func parseSignedData(data []byte) (*PKCS7, error) {
 	var sd signedData
-	asn1.Unmarshal(data, &sd)
+	if _, err := asn1.Unmarshal(data, &sd); err != nil {
+		return nil, err
+	}
 	certs, err := sd.Certificates.Parse()
 	if err != nil {
 		return nil, err

--- a/verify_test_dsa.go
+++ b/verify_test_dsa.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -69,27 +68,27 @@ A ship in port is safe,
 but that's not what ships are built for.
 -- Grace Hopper`)
 	// write the content to a temp file
-	tmpContentFile, err := ioutil.TempFile("", "TestDSASignWithOpenSSLAndVerify_content")
+	tmpContentFile, err := os.CreateTemp("", "TestDSASignWithOpenSSLAndVerify_content")
 	if err != nil {
 		t.Fatal(err)
 	}
-	ioutil.WriteFile(tmpContentFile.Name(), content, 0755)
+	_ = os.WriteFile(tmpContentFile.Name(), content, 0755)
 
 	// write the signer cert to a temp file
-	tmpSignerCertFile, err := ioutil.TempFile("", "TestDSASignWithOpenSSLAndVerify_signer")
+	tmpSignerCertFile, err := os.CreateTemp("", "TestDSASignWithOpenSSLAndVerify_signer")
 	if err != nil {
 		t.Fatal(err)
 	}
-	ioutil.WriteFile(tmpSignerCertFile.Name(), dsaPublicCert, 0755)
+	_ = os.WriteFile(tmpSignerCertFile.Name(), dsaPublicCert, 0755)
 
 	// write the signer key to a temp file
-	tmpSignerKeyFile, err := ioutil.TempFile("", "TestDSASignWithOpenSSLAndVerify_key")
+	tmpSignerKeyFile, err := os.CreateTemp("", "TestDSASignWithOpenSSLAndVerify_key")
 	if err != nil {
 		t.Fatal(err)
 	}
-	ioutil.WriteFile(tmpSignerKeyFile.Name(), dsaPrivateKey, 0755)
+	_ = os.WriteFile(tmpSignerKeyFile.Name(), dsaPrivateKey, 0755)
 
-	tmpSignedFile, err := ioutil.TempFile("", "TestDSASignWithOpenSSLAndVerify_signature")
+	tmpSignedFile, err := os.CreateTemp("", "TestDSASignWithOpenSSLAndVerify_signature")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +103,7 @@ but that's not what ships are built for.
 	}
 
 	// verify the signed content
-	pemSignature, err := ioutil.ReadFile(tmpSignedFile.Name())
+	pemSignature, err := os.ReadFile(tmpSignedFile.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/verify_test_dsa.go
+++ b/verify_test_dsa.go
@@ -1,5 +1,3 @@
-// +build go1.11 go1.12 go1.13 go1.14 go1.15
-
 package pkcs7
 
 import (


### PR DESCRIPTION
- Remove usage of deprecated golint tool
- GHA runs golangci-lint and go tests
- Makefile is cleaned up and runs golangci-lint
- Tests pass when run by GHA or by Makefile
- Resolve golangci-lint's complaints
- Migrate from `ioutil` to `os`